### PR TITLE
Configure the default podman events_logger to 'file'

### DIFF
--- a/src/podman/devcontainer-feature.json
+++ b/src/podman/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "podman",
-    "version": "1.0.3",
+    "version": "1.1.0",
     "name": "Podman (from OS)",
     "documentationURL": "https://github.com/bcook254/devcontainer-features/tree/main/src/podman",
     "description": "Manage containers, pods, and images with Podman. Seamlessly work with containers and Kubernetes from your local environment.",
@@ -9,6 +9,12 @@
             "default": "latest",
             "description": "The version of podman to install.",
             "proposals": [ "latest" ],
+            "type": "string"
+        },
+        "eventsLogger": {
+            "default": "file",
+            "description": "The events logger that podman will be configured to use.",
+            "enum": [ "journald", "file", "none" ],
             "type": "string"
         }
     }

--- a/src/podman/install.sh
+++ b/src/podman/install.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 PODMAN_VERSION=${VERSION}
+PODMAN_EVENTS_LOGGER=${EVENTSLOGGER}
 
 # Bring in ID, ID_LIKE, VERSION_ID, VERSION_CODENAME
 . /etc/os-release
@@ -101,7 +102,7 @@ if [ $ID = "mariner" ]; then
     check_packages ca-certificates
 fi
 PACKAGE=podman
-if [ "$PODMAN_VERSION" != "latest"]; then
+if [ "$PODMAN_VERSION" != "latest" ]; then
     case "$INSTALL_CMD" in
         "apt-get")
             PACKAGE="${PACKAGE}=${PODMAN_VERSION}"
@@ -112,5 +113,11 @@ if [ "$PODMAN_VERSION" != "latest"]; then
     esac
 fi
 check_packages $PACKAGE
+
+# Change the default events_logger for podman as most
+# containers do not run systemd/journald
+mkdir -p /etc/containers/containers.conf.d
+printf "[engine]\nevents_logger = \"${PODMAN_EVENTS_LOGGER}\"" > /etc/containers/containers.conf.d/events_logger.conf
+
 # Clean up
 clean_up


### PR DESCRIPTION
Most containers do not run systemd/journald which results in errors when logging events from podman and also makes the events unavailable later